### PR TITLE
Info provider fixes

### DIFF
--- a/skeleton/.dockerignore
+++ b/skeleton/.dockerignore
@@ -6,6 +6,7 @@
 
 !package.json
 !yarn.lock
+!version
 !.yarn/**
 !.yarnrc.yml
 !.pnp.cjs

--- a/skeleton/.gitignore
+++ b/skeleton/.gitignore
@@ -27,6 +27,7 @@ src/main/views/govuk
 coverage/
 smoke-output/
 functional-output/
+version
 
 # yarn v2
 .yarn/*


### PR DESCRIPTION
Dockerfile needs to not exclude the info provider for it to actually provide version info.

same as https://github.com/hmcts/expressjs-template/pull/689